### PR TITLE
Fixed typo in repo address

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Set a field in `extra` with a key of `site_menus`:
 
 ```toml
 site_menus = [
-  { url = "https://github/hulufei.com/solar-theme-zola", name = "Repository" },
+  { url = "https://github.com/hulufei/solar-theme-zola", name = "Repository" },
   { url = "rss.xml", name = "RSS" },
 ]
 ```


### PR DESCRIPTION
Fixed a typo in the `README.md` file. The URL to this repository was typed in incorrectly. :wave: 